### PR TITLE
Ratings Update: Part II

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,22 @@
 {
-  "name"			      : "My Extensions",
-  "version"			    : "0.9.4.5",
-  "description"		  : "Are you an extensions developer? Keep track of your Chrome extensions. Be notified for new comments, ratings and more!",
+  "name"  		: "My Extensions",
+  "version"			: "0.9.4.6",
+  "description"		: "Are you an extensions developer? Keep track of your Chrome extensions. Be notified for new comments, ratings and more!",
   "background_page" : "background.html",
   "options_page"    : "options.html",
-  
-  
-  "browser_action"     : {
-    "default_icon"  : "icons/19.png",
-    "default_title" : "My Extensions",
-    "popup"         : "popup.html"
-  },
-  
 
-  "icons": {
-    "19": "icons/19.png",
-    "32": "icons/32.png",
-    "48": "icons/48.png"
+  "browser_action"	: {
+    "default_icon"	: "icons/19.png",
+    "default_title"	: "My Extensions",
+    "popup"			: "popup.html"
+  },
+
+  "icons"	: {
+    "19"	: "icons/19.png",
+    "32"	: "icons/32.png",
+    "48"	: "icons/48.png"
   },  
-  
+
   "permissions": [
     "tabs",
     "bookmarks",
@@ -32,6 +30,6 @@
     "http://chrome.pathfinder.gr/*",
     "https://clients2.google.com/*"
   ],
-  
+
   "update_url": "http://clients2.google.com/service/update2/crx"
 }


### PR DESCRIPTION
This fixes the #14 where rating diffs were disappearing in subsequent updates. This was caused by `ratings.previousAverage` always being set to the old value of `ratings.average` instead of only when it's changed. Simple fix.

Also made a minor fix for user count diff and cosmetic fix to options page message when no extensions have been added, which prevents it overlapping the page's title.
