### PR TITLE
Fix for comments not getting updated.

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -1703,7 +1703,7 @@ Ext.Extension = new Class({
 				var responseText	= xhr.responseText ? xhr.responseText.trim() : '';
 
 				if (responseText) {
-					matches = responseText.match(/({"annotations":\[[\s\S]*\],"numAnnotations":\d+,"numAnnotationsAccuracy":\d+})/i);
+					matches = responseText.match(/({"annotations":\[[\s\S]*\].*"numAnnotations":\d+.*"numAnnotationsAccuracy":\d+.*?})/i);
 
 					if (matches && matches.length > 1) {
 						data = JSON.parse(matches[1]);


### PR DESCRIPTION
This is a fix for the comments no longer getting updated.

The problem is that Google is no longer returning the JSON for the comments in the expected format. Some of the JSON fields have changed position. This fix updates the regular expression to parse the JSON correctly.

This allows the latest comments to display and also the progress bar now correctly updates to 100%.